### PR TITLE
Updated django-mode to attempt to require 'python' then 'python-mode'

### DIFF
--- a/django-mode.el
+++ b/django-mode.el
@@ -21,7 +21,11 @@
 
 ;;; Code:
 
-(require 'python-mode)
+(condition-case nil
+    (require 'python)
+  (error
+   (require 'python-mode)))
+
 
 (setq django-template-regexp ".*\\(@render_to\\|render_to_response\\|TemplateResponse\\)(['\"]\\([^'\"]*\\)['\"].*
 ?"


### PR DESCRIPTION
There is a newer python mode (https://github.com/fgallina/python.el) that is getting traction that I figured it'd be nice to have django-mode check for first before falling back to the usual python-mode.

Supposedly it's going to get integrated into the emacs trunk at some point...but who knows when that's going to happen.
