### PR TITLE
Add autoload cookies to django-mode.el

### DIFF
--- a/django-mode.el
+++ b/django-mode.el
@@ -144,6 +144,7 @@
       (insert ")")
       (point-max))))
 
+;;;###autoload
 (define-derived-mode django-mode python-mode "Django" "Major mode for Django web framework.")
 (define-key django-mode-map (kbd "C-t") 'django-insert-transpy)
 (define-key django-mode-map (kbd "C-x j") 'django-jump)
@@ -178,6 +179,7 @@
 
 (easy-menu-add django-menu django-mode-map)
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\<\\(models\\|views\\|handlers\\|feeds\\|sitemaps\\|admin\\|context_processors\\|urls\\|settings\\|tests\\|assets\\|forms\\).py" . django-mode))
 
 (provide 'django-mode)


### PR DESCRIPTION
I am planning to add this pacage to [MELPA](http://melpa.milkbox.net/).This commit ensures that users who have installed `django-mode` from [MELPA](http://melpa.milkbox.net/) will be able to automatically turn on `django-mode` when visiting django file without explicitly requiring the library first.
