### PR TITLE
Add auto-mode-alist with autoload cookie

### DIFF
--- a/django-html-mode.el
+++ b/django-html-mode.el
@@ -479,6 +479,9 @@ If tags are unbalanced, raise error."
       (point-max))))
 (define-key django-html-mode-map (kbd "C-t") 'django-insert-trans)
 
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.djhtml$" . django-html-mode))
+
 ;; This part ends here
 
 (provide 'django-html-mode)


### PR DESCRIPTION
This commit ensures that users who have installed `django-html-mode` from [MELPA](http://melpa.milkbox.net/)  will be able to automatically turn on `django-html-mode` when visiting a djhtmlfile without explicitly requiring the library first.

In connection with myfreeweb/django-mode#12
