### PR TITLE
Add django-snippets.el

### DIFF
--- a/django-snippets.el
+++ b/django-snippets.el
@@ -1,0 +1,43 @@
+;;; django-snippets.el --- Yasnippets for django
+
+;; Copyright (C) 2013 Yasuyuki Oka <yasuyk@gmail.com>
+
+;; Author: Yasuyuki Oka <yasuyk@gmail.com>
+;; URL: https://github.com/myfreeweb/django-mode
+;; Package-Requires: ((yasnippet "0.8.0"))
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(defvar django-snippets-dir
+  (file-name-directory (or (buffer-file-name) load-file-name)))
+
+;;;###autoload
+(defun django-snippets-initialize ()
+  (let ((snip-dir (expand-file-name "snippets" django-snippets-dir)))
+    (add-to-list 'yas-snippet-dirs snip-dir t)
+    (yas-load-directory snip-dir)))
+
+;;;###autoload
+(eval-after-load 'yasnippet
+   '(django-snippets-initialize))
+
+(require 'yasnippet)
+
+(provide 'django-snippets)
+
+;;; django-snippets.el ends here


### PR DESCRIPTION
`django-snippets.el` ensures that users who have installed `django-snippets.el` from [MELPA](http://melpa.milkbox.net/)  will be able to automatically load snippets for django-mode and djang-html-mode without explicitly loading snippet directory first.

In connection with myfreeweb/django-mode#12
