### PR TITLE
Fix for new python.el

### DIFF
--- a/django-mode.el
+++ b/django-mode.el
@@ -80,7 +80,9 @@
 
 
 (defun django-python-command ()
-  (mapconcat 'identity (cons python-python-command python-python-command-args) " "))
+  (if (boundp 'python-shell-interpreter)
+      (concat python-shell-interpreter " " python-shell-interpreter-args)
+    (mapconcat 'identity (cons python-python-command python-python-command-args) " ")))
 
 (defun django-manage (command)
   (interactive "sCommand:")


### PR DESCRIPTION
`python-python-command` and `python-python-command-args` are no longer used.

I got following error when I evaluate `M-x (django-python-command)`

```
Debugger entered--Lisp error: (void-variable python-python-command)
  (cons python-python-command python-python-command-args)
  (mapconcat (quote identity) (cons python-python-command python-python-command-args) " ")
  django-python-command()
  eval((django-python-command) nil)
  eval-expression((django-python-command) nil)
  call-interactively(eval-expression nil nil)
  command-execute(eval-expression)
```
