### PR TITLE
Improve auto-mode-alist regexp

### DIFF
--- a/django-mode.el
+++ b/django-mode.el
@@ -182,7 +182,7 @@
 (easy-menu-add django-menu django-mode-map)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\<\\(models\\|views\\|handlers\\|feeds\\|sitemaps\\|admin\\|context_processors\\|urls\\|settings\\|tests\\|assets\\|forms\\).py" . django-mode))
+(add-to-list 'auto-mode-alist '("\\<\\(models\\|views\\|handlers\\|feeds\\|sitemaps\\|admin\\|context_processors\\|urls\\|settings\\|tests\\|assets\\|forms\\)\\.py\\'" . django-mode))
 
 (provide 'django-mode)
 ;; django-mode.el ends here


### PR DESCRIPTION
- escape '.' in regexp because '.' matchs any characters
- add string end anchor(`\\'`) to end of regexp