### PR TITLE
Declare global variables with defvar

### DIFF
--- a/django-mode.el
+++ b/django-mode.el
@@ -26,12 +26,13 @@
   (error
    (require 'python-mode)))
 
+(defvar django-template-regexp ".*\\(@render_to\\|render_to_response\\|TemplateResponse\\)(['\"]\\([^'\"]*\\)['\"].*
+?")
 
-(setq django-template-regexp ".*\\(@render_to\\|render_to_response\\|TemplateResponse\\)(['\"]\\([^'\"]*\\)['\"].*
-?"
-      django-view-regexp ".*(.+, ?['\"]\\([^'\",]+\\)['\"].*).*
-?"
-      django-model-regexp "^[^.]* \\([^.,]+\\)\\(.objects\\|(\\).*
+(defvar django-view-regexp ".*(.+, ?['\"]\\([^'\",]+\\)['\"].*).*
+?")
+
+(defvar django-model-regexp "^[^.]* \\([^.,]+\\)\\(.objects\\|(\\).*
 ?")
 
 (defun django-root (&optional dir home)


### PR DESCRIPTION
Global variables should be declared. Using not declared variables
causes byte compile warnings.
