### PR TITLE
Get all manage.py commands, get make targets, menus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ BTW, default keybindings:
 - `C-c t` runs tests
 - `C-c s` runs syncdb
 - `C-c a` creates an app (asking for a name first)
-- `C-c m` asks you for a command to run
+- `C-c m` asks you for a command to run (with completion of available commands)

--- a/django-mode.el
+++ b/django-mode.el
@@ -46,7 +46,7 @@
            ;; (file-exists-p (expand-file-name "manage.py" dir)))
       ;; dir
     ;; (let ((new-dir (expand-file-name (file-name-as-directory "..") dir)))
-      regexp to match windows roots, tramp roots, or regular posix roots
+      ;; regexp to match windows roots, tramp roots, or regular posix roots
       ;; (unless (string-match "\\(^[[:alpha:]]:/$\\|^/[^\/]+:\\|^/$\\)" dir)
         ;; (django-root new-dir)))))
       )
@@ -122,6 +122,34 @@
   ;; Now ask to edit the command. How to do the two actions at once ?
   (setq command (read-shell-command "Run command like this: " command))
   (compile (concat (django-python-command) " " (django-root) "manage.py " command)))
+
+(defun django-get-make-commands ()
+  "Extract the commands from the Makefile."
+  (cd-absolute (django-root))  ;; TODO: I don't like it
+  (with-temp-buffer
+    (progn
+      (insert-file-contents "Makefile")
+  (save-restriction
+    (setq dj-results '())               ; don't use global variables TODO:
+    (goto-char 1)
+    (let ((case-fold-search nil))
+      (setq dj-results '())
+      (while (search-forward-regexp "^[a-z0-9]+" nil t) ;; regexp is weak
+        (progn
+          (if (null dj-results) (setq dj-results (list (match-string 0)))
+          (setq dj-results (cons (match-string 0) dj-results)))
+
+        ))
+      dj-results)))
+))
+
+(defun django-make (command)
+  "Suggest make commands to run, based on a simple parsing of the Makefile."
+  (interactive (list (ido-completing-read "make: " (django-get-make-commands))))
+  (cd-absolute (django-root))           ;; TODO: I don't like absolute cd.
+  (compile (concat "make" " " command))
+)
+
 
 (defun django-syncdb ()
   (interactive)

--- a/django-mode.el
+++ b/django-mode.el
@@ -128,6 +128,19 @@
   (setq command (read-shell-command "Run command like this: " command))
   (compile (concat (django-python-command) " " (django-root) "manage.py " command)))
 
+(defun django-run-in-shell (command)
+  "run the given command in a shell. Useful in development to use breakpoints."
+  (setq django-shell-buffer-name (format "*shell %s*" (projectile-project-name)))
+  (setq django-shell-buffer (get-buffer django-shell-buffer-name))
+  ;; TODO: open shell if needed
+  ;; stop shell execution if needed
+  (set-buffer django-shell-buffer)
+  (comint-kill-input)
+  (insert command)
+  (comint-send-input)
+)
+
+
 (defun django-get-make-commands ()
   "Extract the commands from the Makefile."
   (cd-absolute (django-root))  ;; TODO: I don't like it

--- a/django-mode.el
+++ b/django-mode.el
@@ -160,7 +160,7 @@
                       (setq dj-results (cons (match-string 0) dj-results)))
 
                     ))
-                dj-results)))))
+                (nreverse dj-results))))))
     '("")  ;; not void or the detached menu would disappear. We could offer an option.
 ))
 

--- a/django-mode.el
+++ b/django-mode.el
@@ -102,12 +102,13 @@
                                ;; cleanup [auth] and stuff
                                (beginning-of-buffer)
                                (save-excursion
-                               (replace-regexp "\\[.*\\]" ""))  ;; the message "replaced x occurences" is annoying.
+                                 (while (re-search-forward "\\[.*\\]" nil t)
+                                   (replace-match "" nil nil)))
                                (buffer-string)
                                )))
           ;; get a list of commands from the output of manage.py -h
           ;; What would be the pattern to optimize this ?
-          (message "updated manage.py commands.") ;; called quite often.
+          ;; (message "updated manage.py commands.") ;; called quite often.
           (setq dj-commands-str (s-split "\n" dj-commands-str))
           (setq dj-commands-str (-remove (lambda (x) (string= x "")) dj-commands-str))
           (setq dj-commands-str (mapcar (lambda (x) (s-trim x)) dj-commands-str))

--- a/django-mode.el
+++ b/django-mode.el
@@ -150,6 +150,26 @@
   (compile (concat "make" " " command))
 )
 
+;; Dynamic menu to list the make commands.
+(easy-menu-define django--make-menu global-map "Django make"
+  '("Django make"))
+
+
+(defun django--get-menu ()
+  (easy-menu-create-menu
+   "Django make"
+   (mapcar (lambda (command)
+             (vector  command
+                     `(lambda () (interactive) (compile (concat "make" " " ,command)) t)))
+           (django-get-make-commands))))
+
+(easy-menu-add-item django--make-menu '() (django--get-menu))
+
+(defun django--update-menu ()
+  (easy-menu-add-item django--make-menu '() (django--get-menu)))
+
+(add-hook 'menu-bar-update-hook 'django--update-menu)
+
 
 (defun django-syncdb ()
   (interactive)

--- a/django-mode.el
+++ b/django-mode.el
@@ -144,21 +144,24 @@
 (defun django-get-make-commands ()
   "Extract the commands from the Makefile."
   (cd-absolute (django-root))  ;; TODO: I don't like it
-  (with-temp-buffer
-    (progn
-      (insert-file-contents "Makefile")
-  (save-restriction
-    (setq dj-results '())               ; don't use global variables TODO:
-    (goto-char 1)
-    (let ((case-fold-search nil))
-      (setq dj-results '())
-      (while (search-forward-regexp "^[a-z0-9]+" nil t) ;; regexp is weak
-        (progn
-          (if (null dj-results) (setq dj-results (list (match-string 0)))
-          (setq dj-results (cons (match-string 0) dj-results)))
+  (if (file-exists-p "Makefile")
+      (progn
+        (with-temp-buffer
+          (progn
+            (insert-file-contents "Makefile")
+            (save-restriction
+              (setq dj-results '())               ; don't use global variables TODO:
+              (goto-char 1)
+              (let ((case-fold-search nil))
+                (setq dj-results '())
+                (while (search-forward-regexp "^[a-z0-9-]+" nil t) ;; regexp is weak
+                  (progn
+                    (if (null dj-results) (setq dj-results (list (match-string 0)))
+                      (setq dj-results (cons (match-string 0) dj-results)))
 
-        ))
-      dj-results)))
+                    ))
+                dj-results)))))
+    '("")  ;; not void or the detached menu would disappear. We could offer an option.
 ))
 
 (defun django-make (command)


### PR DESCRIPTION
Hi there,
I worked to improve the django mode to my taste a few months ago. I think some features can be useful but it isn't really finished and polished yet, and I'd like some help and reviews for that.

What I implemented:
- I wanted completion of available commands
- I wanted to run every possible command available with manage.py (even the ones from plugins like django-extensions)
I did  it by parsing its help output. Now, when one runs `C-c m` (django-manage) he gets the full list of commands, with auto-completion, with a chance to edit it before running it.

- Since I use a Makefile I wanted the same for makefiles, so I do it likewise, by parsing the Makefile at the project root and catching targets with a little regexp. I wonder wether I should put that in a separate project.
- And since Django-mode has a nice menu, and I like it for beginners to have a menu, I tried to add a menu for the django commands and another one for the make commands, but I couldn't do exactly what I want: I only managed to create the menu entries at the left of the menu bar.

With this PR, I'd like to hear you about the new features and I'd love to read your code reviews and discuss wether and how we should/can merge that. Thanks !