### PR TITLE
Get the list of all available commands, choose with ido completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ BTW, default keybindings:
 - `C-c t` runs tests
 - `C-c s` runs syncdb
 - `C-c a` creates an app (asking for a name first)
-- `C-c m` asks you for a command to run
+- `C-c m` asks for a command to run (with completion of all available commands and ido completion)


### PR DESCRIPTION
""so than we can select management commands that come with extensions too.
We parse the output of manage.py -h
Choose the command with ido completion, and offer a chance to edit it."

Hi !
This is a smaller PR to carry on and replace work on PR https://github.com/myfreeweb/django-mode/pull/18
I've been using this for months, and now the code is much better.

You're not maintaining django-mode any more, and I feel confident now, so as you suggested a year ago yes, I'd like to have collaborator access (or anything you see fit). Thanks !

btw I'd like to do more stuff, like running tests with elpy (working on it, [here](https://github.com/jorgenschaefer/elpy/issues/931) and [here](https://github.com/jorgenschaefer/elpy/issues/932)), have a nice hydra, run commands taken from the Makefile (already have it from the previous PR, integrate more of projectile, etc).

