### PR TITLE
django-make: run a make target with helm completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Select a string you want to translate and press `C-t`. This works in both Python
 Check out the Django menu :)
 BTW, default keybindings:
 
+- `C-c m` asks for a command to run (with completion of all available commands and ido completion)
 - `C-c t` runs tests
 - `C-c s` runs syncdb
 - `C-c a` creates an app (asking for a name first)
-- `C-c m` asks for a command to run (with completion of all available commands and ido completion)
+
+## Running a make target
+With `M-x django-make` (`C-c M` in django-mode), you get a helm menu to choose a Makefile target. It will run from the project root (we use [helm-make](https://github.com/abo-abo/helm-make)).

--- a/django-mode.el
+++ b/django-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Greg V <floatboth@me.com>
 ;; Keywords: languages
-;; Package-Requires: ((projectile "0") (s "0"))
+;; Package-Requires: ((projectile "0") (s "0") (helm-make "0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -27,6 +27,7 @@
   (error
    (require 'python-mode)))
 
+(require 'helm-make)
 (require 'projectile)
 (require 's)
 
@@ -120,6 +121,11 @@
   (let ((command (read-shell-command "Run command like this: " command)))
     (compile (concat (django-python-command) " " (django-root) "manage.py " command))))
 
+(defun django-make ()
+  "Ask for a make target with helm, run it from project's root."
+  (interactive)
+  (call-interactively 'helm-make-projectile)
+
 (defun django-syncdb ()
   (interactive)
   (django-manage "syncdb --noinput"))
@@ -186,6 +192,7 @@
 (define-key django-mode-map (kbd "C-c t") 'django-test)
 (define-key django-mode-map (kbd "C-c s") 'django-syncdb)
 (define-key django-mode-map (kbd "C-c a") 'django-startapp)
+(define-key django-mode-map (kbd "C-c M") 'django-make)
 (add-hook 'django-mode-hook
           (lambda ()
             (font-lock-add-keywords nil


### PR DESCRIPTION
Hi,
This is also a feature that I have on my side from a long time, but now I rely on abo-abo's helm-make.
This offers a new command and a new shortcut to have an helm completion of the make targets. It then runs from the project root and calls "compile".