### PR TITLE
Fix closing parenthesis

### DIFF
--- a/django-mode.el
+++ b/django-mode.el
@@ -51,7 +51,6 @@
       ;; regexp to match windows roots, tramp roots, or regular posix roots
       (unless (string-match "\\(^[[:alpha:]]:/$\\|^/[^\/]+:\\|^/$\\)" dir)
         (django-root new-dir)))))
-      )
 
 (defun django-jump-to-template ()
   (interactive)
@@ -124,7 +123,7 @@
 (defun django-make ()
   "Ask for a make target with helm, run it from project's root."
   (interactive)
-  (call-interactively 'helm-make-projectile)
+  (call-interactively 'helm-make-projectile))
 
 (defun django-syncdb ()
   (interactive)


### PR DESCRIPTION
I got an error about excess parenthesis when trying to install this package, so I tracked it down and removed it. It then complained about missing parenthesis, so I added one where it seemed to be missing.

It seems that the last one was added 6 months ago, and the first one 3 years ago, so I'm surprised that no one else has caught it.